### PR TITLE
fix: remove device pairing after authenticated remote revoke

### DIFF
--- a/cli/src/backendSocket.ts
+++ b/cli/src/backendSocket.ts
@@ -429,7 +429,14 @@ export class BackendSocket {
   }
   private autonomousDeviceRelay?: AutonomousDeviceRelay
   setAutonomousDeviceService(service: AutonomousDeviceService): void {
-    this.autonomousDeviceRelay = new AutonomousDeviceRelay(this.e2ee, (connId, frame) => this.sendTo(connId, frame), service, this.machineId, () => this.onCommanderJoin?.())
+    this.autonomousDeviceRelay = new AutonomousDeviceRelay(
+      this.e2ee,
+      (connId, frame) => this.sendTo(connId, frame),
+      service,
+      this.machineId,
+      () => this.onCommanderJoin?.(),
+      identity => this.e2ee.revoke(fingerprint(b64d(identity))),
+    )
   }
   directAutonomousDeviceSessions(): number { return this.autonomousDeviceRelay?.count(id => this.directDeviceSinks.has(id)) ?? 0 }
   autonomousDeviceConnected(): boolean { return this.autonomousDeviceRelay?.connected() ?? false }

--- a/cli/src/lib/autonomous-device/relay.spec.ts
+++ b/cli/src/lib/autonomous-device/relay.spec.ts
@@ -9,9 +9,10 @@ function fixture() {
     unwrapDown: (_c: string, frame: Record<string, unknown>) => ({ ...frame, payload: (frame.payload as { __e2e: unknown }).__e2e }),
     wrapTarget: (_c: string, type: string, payload: Record<string, unknown>) => ({ type, payload: { __e2e: payload } }) }
   const service = new AutonomousDeviceService({ machineId: 'machine', agents: () => [{ agentId: 'agent', name: 'Agent', engine: 'codex', state: 'idle' }], submit, cancelDelivery: cancel, stop: async () => true, answer: async () => true, recent: () => [] })
-  const relay = new AutonomousDeviceRelay(crypto, send, service, 'machine')
+  const remoteRevoke = vi.fn()
+  const relay = new AutonomousDeviceRelay(crypto, send, service, 'machine', undefined, remoteRevoke)
   const request = (payload: Record<string, unknown>) => relay.handle('conn', { type: 'autonomous_device_request', payload: { __e2e: payload } })
-  return { relay, request, send, submit, service, cancel, setRole: (r: string) => { role = r }, revoke: () => { identity = null } }
+  return { relay, request, send, submit, service, cancel, remoteRevoke, setRole: (r: string) => { role = r }, revoke: () => { identity = null } }
 }
 describe('Autonomous device existing E2EE relay seam', () => {
   it('requires existing device-role trust and encrypted payload before calling the service', async () => {
@@ -33,5 +34,18 @@ describe('Autonomous device existing E2EE relay seam', () => {
     expect(f.cancel).toHaveBeenCalledOnce()
     expect(f.service.receipt('trusted-device', 'one')).toBeNull()
     await f.request(req); expect(f.submit).toHaveBeenCalledTimes(1)
+  })
+  it('removes a device pairing only after its authenticated revoke request', async () => {
+    const f = fixture(); await f.request({ type: 'hello', proto: 1, requestId: randomUUID() })
+    await f.request({ type: 'pair.revoke', requestId: randomUUID() })
+    expect(f.send.mock.calls.at(-1)?.[1]).toMatchObject({
+      type: 'autonomous_device_result', payload: { __e2e: { type: 'pair.revoke_result', revoked: true } },
+    })
+    expect(f.remoteRevoke).toHaveBeenCalledWith('trusted-device')
+  })
+  it('does not revoke when the request is malformed', async () => {
+    const f = fixture(); await f.request({ type: 'hello', proto: 1, requestId: randomUUID() })
+    await f.request({ type: 'pair.revoke', requestId: randomUUID(), extra: true })
+    expect(f.remoteRevoke).not.toHaveBeenCalled()
   })
 })

--- a/cli/src/lib/autonomous-device/relay.ts
+++ b/cli/src/lib/autonomous-device/relay.ts
@@ -8,7 +8,8 @@ export class AutonomousDeviceRelay {
   private readonly clients = new Map<string, { identity: string; tokens: number; at: number; active: number }>()
   constructor(private readonly crypto: Pick<E2eeManager, 'sessionIdentity' | 'sessionRole' | 'unwrapDown' | 'wrapTarget'>,
     private readonly send: (connId: string, frame: Frame) => void,
-    private readonly service: AutonomousDeviceService, private readonly machineId: string, private readonly onReady?: () => void) {}
+    private readonly service: AutonomousDeviceService, private readonly machineId: string, private readonly onReady?: () => void,
+    private readonly onRemoteRevoke?: (identity: string) => void) {}
   count(include: (connId: string) => boolean = () => true): number { return [...this.clients].filter(([id, client]) => include(id) && this.crypto.sessionIdentity(id) === client.identity && this.crypto.sessionRole(id) === 'device').length }
   connected(): boolean { return this.count() > 0 }
   private sendTo(connId: string, identity: string, type: string, payload: Frame): void {
@@ -36,6 +37,18 @@ export class AutonomousDeviceRelay {
     }
     const client = this.clients.get(connId)
     if (!client || client.identity !== identity) { reply({ type: `${req.type}_result`, requestId: req.requestId, error: { code: 'HELLO_REQUIRED', message: 'Send application hello first' } }); return }
+    // A device deleting its local trust must say so while the authenticated channel still exists.
+    // A socket close alone is deliberately only an offline signal: treating it as revocation would
+    // unpair users whenever their LAN briefly drops.
+    if (req.type === 'pair.revoke') {
+      if (typeof req.requestId !== 'string' || Object.keys(req).some(key => key !== 'type' && key !== 'requestId')) {
+        reply({ type: 'pair.revoke_result', requestId: req.requestId, error: { code: 'INVALID_REQUEST', message: 'Invalid device revoke request' } })
+        return
+      }
+      reply({ type: 'pair.revoke_result', requestId: req.requestId, revoked: true })
+      this.onRemoteRevoke?.(identity)
+      return
+    }
     const now = Date.now(); client.tokens = Math.min(20, client.tokens + Math.max(0, now - client.at) / 1000); client.at = now
     const error = client.tokens < 1 ? 'RATE_LIMITED' : client.active >= 4 ? 'BACKPRESSURE' : null
     if (error) { reply({ type: `${req.type}_result`, requestId: req.requestId, error: { code: error, message: error } }); return }

--- a/docs/autonomous-device-integration.md
+++ b/docs/autonomous-device-integration.md
@@ -71,6 +71,11 @@ All routes remain on the credential-checked loopback hook server. There is no ne
 Discovery id and trusted fingerprint are distinct identifiers. A user chooses a discovery record
 for pairing; revoke targets the exact existing trusted fingerprint. Original `harness pair` and
 browser/dial UI behavior are unchanged. Direct pairing is initiated by the named facade above.
+When the device revokes its own local trust, it sends the authenticated application request
+`{type:"pair.revoke",requestId}` and waits for `pair.revoke_result` before closing its socket.
+The CLI then removes that exact device identity and its reconnect metadata. A socket close without
+this request remains `offline`, rather than being treated as a revoke, so transient LAN failures do
+not unpair the device.
 
 ## Existing encrypted wire, unchanged
 

--- a/docs/vi/autonomous-device-integration_vi.md
+++ b/docs/vi/autonomous-device-integration_vi.md
@@ -35,6 +35,11 @@ Facade loopback có credential: GET discover; POST pair/start `{code,device}`; G
 GET status (transport direct); GET list (id là fingerprint, khác discoveryId); POST revoke `{id}`;
 GET receipt query deviceId canonical publickey và idempotencyKey. Không listen/address/replace/all.
 
+Khi device tự revoke trust cục bộ, nó gửi application request đã xác thực
+`{type:"pair.revoke",requestId}` và đợi `pair.revoke_result` trước khi đóng socket. CLI sẽ xóa đúng
+identity đó cùng metadata reconnect. Socket chỉ đóng mà không có request này vẫn là `offline`, không
+được hiểu là revoke, để lỗi mạng thoáng qua không unpair device.
+
 Wire dùng nguyên e2e_* gốc role device, CI b:device. App outer autonomous_device_request/result/event
 vẫn pairwise encrypted với empty dbSessionId AAD; helper relay.ts chỉ là adapter ứng dụng dùng chung
 crypto, không kết nối backend. Request agents.list/status/recap/turn.send/turn.stop/question.answer/


### PR DESCRIPTION
## Summary
- accept authenticated device self-revoke requests over the existing E2EE relay
- clear the exact CLI pairing and reconnect metadata after acknowledgement
- document the device-to-CLI revoke handshake

## Verification
- npm test -- src/lib/autonomous-device/relay.spec.ts
- npm run typecheck
- npm run build