### PR TITLE
feat(cli): keep Codex account homes isolated per agent

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -141,6 +141,18 @@ claude under a terminal backend ──writes──▶ ~/.claude/projects/**.json
   and a reason specific to it — some talk only to their own service, some need a provider block
   written into a dotfile this daemon will not edit — rather than quietly started on its own login.
   Needs tmux ≥ 3.2; an older one is refused as `TMUX_TOO_OLD_FOR_GRID`. See `src/lib/gridLaunch.ts`.
+- **Codex accounts can use separate state folders.** `engines_probe` advertises
+  `supportsCodexHome: true` for Codex. `agent_create` accepts an optional absolute
+  `codexHome` directory for a Codex launch without a Grid override. It resolves to
+  an existing, writable directory owned by the current user; an invalid explicit
+  choice fails instead of falling back to the daemon's account. This is the
+  `CODEX_HOME` behind a shortcut such as `codex2`, not a shell alias to execute or
+  a named Codex configuration preset. The launch sets it after shell startup;
+  the daemon's environment and credential files are unchanged. Harness merges
+  its hooks into that folder's `hooks.json` and leaves malformed files untouched.
+  Codex may require reviewing those hooks with `/hooks` on first use.
+  Process discovery, transcript binding/repair, model cache lookup and restarts
+  retain the agent's home. Agent frames include the path as `codexHome` when known.
 - **A running agent can be moved to a grid** (`agent_retarget`): `respawn-pane -k -e` re-execs the
   pane's engine with the new launch and `--resume`, keeping the pane, its id and its scrollback, and
   the new process is adopted onto the same agent record. A pane mid-turn is refused (`AGENT_BUSY`)

--- a/cli/src/backendSocket.codexProfile.spec.ts
+++ b/cli/src/backendSocket.codexProfile.spec.ts
@@ -1,0 +1,53 @@
+import { mkdtempSync, realpathSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { BackendSocket } from './backendSocket.js'
+
+let directory: string
+let socket: BackendSocket
+let frames: Array<Record<string, any>>
+beforeEach(() => {
+  directory = mkdtempSync(join(tmpdir(), 'codex-profile-rpc-'))
+  frames = []
+  socket = new BackendSocket('unused-test-token')
+  socket.registerLocalClient('local:profiles', {
+    sendFrame: (frame) => { frames.push(frame); return true },
+    sendBinary: () => true,
+  })
+})
+afterEach(async () => {
+  await socket.unregisterLocalClient('local:profiles')
+  await socket.stop()
+  rmSync(directory, { recursive: true, force: true })
+})
+
+describe('Codex profile launch contract', () => {
+  it('advertises explicit support and hands the canonical path to the launcher', async () => {
+    socket.engineProbeProvider = async () => [{ engine: 'codex', installed: true, command: 'codex', installable: false }]
+    socket.handleLocalFrame('local:profiles', { type: 'engines_probe', payload: { requestId: 'probe', engines: ['codex'] } })
+    await vi.waitFor(() => expect(frames.find((f) => f.type === 'engines_probe_result')?.payload.engines[0].supportsCodexHome).toBe(true))
+    const create = vi.fn(async () => ({ ok: false as const, error: 'TEST_LAUNCH_STOPPED' }))
+    socket.onCreateAgent = create
+    socket.handleLocalFrame('local:profiles', {
+      type: 'agent_create', payload: { requestId: 'create', engine: 'codex', cwd: directory, codexHome: directory },
+    })
+    await vi.waitFor(() => expect(create).toHaveBeenCalledWith({ engine: 'codex', cwd: directory, codexHome: realpathSync(directory), bypassPermission: false, grid: null }))
+  })
+
+  it.each([
+    { engine: 'claude' },
+    { engine: 'codex', codexHome: 'codex2' },
+    { engine: 'codex', codexHome: null },
+    { engine: 'codex', codexHome: '/does-not-exist/profile' },
+    { engine: 'codex', grid: { networkId: 'test-grid', networkName: 'Test grid', baseUrl: 'https://grid.example.test/relay', apiKey: 'test-relay-key' } },
+  ])('rejects an invalid profile before launching: %j', async (override) => {
+    const create = vi.fn(async () => ({ ok: false as const, error: 'SHOULD_NOT_LAUNCH' }))
+    socket.onCreateAgent = create
+    socket.handleLocalFrame('local:profiles', {
+      type: 'agent_create', payload: { requestId: 'refused', cwd: directory, codexHome: directory, ...override },
+    })
+    await vi.waitFor(() => expect(frames.find((f) => f.type === 'agent_create_result')?.payload.error).toBe('INVALID_CODEX_PROFILE'))
+    expect(create).not.toHaveBeenCalled()
+  })
+})

--- a/cli/src/backendSocket.ts
+++ b/cli/src/backendSocket.ts
@@ -27,6 +27,7 @@ import { listDir } from './lib/fsBrowse.js'
 import { parseGridLaunchOverride, type GridLaunchOverride } from './lib/gridLaunch.js'
 import { probeEngines } from './lib/engineProbe.js'
 import { engineInstallRecipe } from './lib/engineInstall.js'
+import { resolveCodexHome } from './lib/codexHome.js'
 import { agentFrame, type AgentFrame } from './lib/agentFrame.js'
 import { routeVoiceTask } from './lib/voiceRouter.js'
 import { tailFile } from './lib/sessions.js'
@@ -313,6 +314,7 @@ export class BackendSocket {
     engine: AgentEngine
     cwd: string
     bypassPermission: boolean
+    codexHome?: string
     /** A grid to point this agent at instead of the engine's own login; null when none was chosen. */
     grid: GridLaunchOverride | null
   }) =>
@@ -1421,6 +1423,7 @@ export class BackendSocket {
                 installed: entry.installed,
                 command: entry.command,
                 installable: entry.installable,
+                ...(entry.engine === 'codex' ? { supportsCodexHome: true } : {}),
                 installCommand: entry.installable ? engineInstallRecipe(entry.engine).command : null,
               })),
             }))
@@ -1520,11 +1523,25 @@ export class BackendSocket {
           // that quietly ran on the engine's own login would look like it worked.
           const grid = parseGridLaunchOverride(payload.grid)
           if (grid.state === 'invalid') { reply(type, requestId, { error: 'INVALID_GRID', detail: grid.reason }); return }
+          let codexHome: string | undefined
+          if (payload.codexHome !== undefined) {
+            if (engine !== 'codex' || grid.state === 'ok') {
+              reply(type, requestId, { error: 'INVALID_CODEX_PROFILE', detail: 'Choose a Codex profile only when using Codex on its own account.' })
+              return
+            }
+            const resolved = resolveCodexHome(payload.codexHome)
+            if (!resolved) {
+              reply(type, requestId, { error: 'INVALID_CODEX_PROFILE', detail: 'The Codex profile folder is missing or is not writable by this machine’s user.' })
+              return
+            }
+            codexHome = resolved
+          }
           const result = await this.onCreateAgent({
             engine,
             cwd,
             bypassPermission: payload.bypassPermission === true,
             grid: grid.state === 'ok' ? grid.override : null,
+            ...(codexHome !== undefined ? { codexHome } : {}),
           })
           // `detail` carries the underlying cause (tmux's own message) so the person who clicked
           // Create can read it, rather than having to open a log on the machine that failed.

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -50,6 +50,7 @@ import { ENGINE_CLI_COMMANDS, ENGINES, engineBin, enginePathOverride } from './l
 import type { AgentEngine } from './engines/types.js'
 import { engineInstallRecipe } from './lib/engineInstall.js'
 import { buildEngineCommandArgv, buildEngineLaunchArgv, commandAvailableInInteractiveShell } from './lib/engineLaunch.js'
+import { resolveCodexHome } from './lib/codexHome.js'
 import { buildGridEngineLaunch, describeGridLaunch, gridConflictingEnvToClear, gridEnvVarNames, type GridEngineLaunch } from './lib/gridLaunch.js'
 import { HERMES_SYSTEM_MANAGED_DIR } from './lib/gridWebMcp.js'
 import { writeGridConfigDir } from './lib/gridConfigDir.js'
@@ -2280,6 +2281,7 @@ async function runForeground(session: AuthSession): Promise<void> {
       // agy cannot be found by directory — its repair reads the presence lock the process holds open.
       //
       const found = await findLiveSession(observed.engine, observed.cwd, startedAtMs, {
+        codexHome: observed.codexHome ?? agent.codexHome,
         bornOnly: true,
         pid: observed.processIdentity.pid,
       })
@@ -2331,6 +2333,7 @@ async function runForeground(session: AuthSession): Promise<void> {
         processIdentity: observed.processIdentity,
         gateway: observed.gateway,
         grid: observed.grid,
+        codexHome: observed.codexHome,
       })
       if (!opened) return
       if (opened.evicted) {
@@ -2360,12 +2363,13 @@ async function runForeground(session: AuthSession): Promise<void> {
       // could not look, which never counts as a move — see `probeGridAssignment`'s three answers.
       const gridMoved = observed.grid !== undefined
         && !sameGridAssignment(current.grid ?? null, observed.grid)
+      const profileChanged = observed.codexHome !== undefined && current.codexHome !== observed.codexHome
       const wasLaunching = current.launch?.state !== undefined && current.launch.state !== 'ready'
       registry.updateRuntimes(current.agentId, observed.runtimes, observed.primaryRuntimeKey)
-      registry.updateProcessIdentity(current.agentId, observed.processIdentity, observed.gateway, observed.grid)
+      registry.updateProcessIdentity(current.agentId, observed.processIdentity, observed.gateway, observed.grid, observed.codexHome)
       if (wasLaunching) registry.setLaunch(current.agentId, { state: 'ready' })
       await bindObservedAgent(observed)
-      if (wasDormant || wasLaunching) {
+      if (wasDormant || wasLaunching || profileChanged) {
         const active = registry.byAgent(current.agentId)
         if (!active) return
         if (active.sessionId && !await attachSession(active)) {
@@ -3295,12 +3299,15 @@ async function runForeground(session: AuthSession): Promise<void> {
     return undefined
   }
 
-  backend.onCreateAgent = async ({ engine, cwd, bypassPermission, grid }) => {
+  backend.onCreateAgent = async ({ engine, cwd, bypassPermission, grid, codexHome }) => {
     if (!tmuxBackend) return { ok: false, error: 'TMUX_UNAVAILABLE' }
     try {
       if (!statSync(cwd).isDirectory()) return { ok: false, error: 'CWD_NOT_FOUND' }
     } catch {
       return { ok: false, error: 'CWD_NOT_FOUND' }
+    }
+    if (codexHome !== undefined && !installCodexHooks(hookPort, codexHome)) {
+      return { ok: false, error: 'CODEX_PROFILE_SETUP_FAILED', detail: 'Could not prepare this Codex profile’s Harness hooks. Check its hooks.json and folder permissions.' }
     }
     // Harness-created sessions are easy to distinguish from a user's organic tmux sessions while
     // retaining the engine and a collision-resistant creation suffix for diagnostics. Computed
@@ -3354,7 +3361,7 @@ async function runForeground(session: AuthSession): Promise<void> {
     // only `invalid x-api-key`. Nothing is cleared when no grid is in play: an agent on its own login
     // is supposed to use exactly these variables.
     const clearEnv = gridLaunch ? gridConflictingEnvToClear(gridLaunch) : undefined
-    const launchOptions = { bypassPermission, extraArgs: gridLaunch?.args, installIfMissing, clearEnv, cwd }
+    const launchOptions = { bypassPermission, extraArgs: gridLaunch?.args, installIfMissing, clearEnv, cwd, codexHome }
     const command = buildEngineCommandArgv(engine, launchOptions)
     const argv = buildEngineLaunchArgv(engine, launchOptions)
     // A tmux route is enough to stream its screen. Register it before looking for a process so both
@@ -3374,6 +3381,7 @@ async function runForeground(session: AuthSession): Promise<void> {
       argv,
       env: gridLaunch?.env,
       grid: grid ? { baseUrl: grid.baseUrl, model: grid.model ?? null } : null,
+      codexHome,
     })
     if (!result.ok) return { ok: false, error: result.error, detail: result.detail }
     const { spawned, pending } = result
@@ -3449,6 +3457,9 @@ async function runForeground(session: AuthSession): Promise<void> {
     launch: { env?: Record<string, string>; extraArgs?: readonly string[] } = {},
   ): RestartAgentDeps => ({
     holdOpen: async () => {
+      if (session.codexHome !== undefined && !resolveCodexHome(session.codexHome)) {
+        return { ok: false, reason: 'This agent’s Codex profile folder is unavailable. Restore it before restarting.' }
+      }
       const result = await tmuxBackend!.holdOpen(runtime)
       return result.state === 'succeeded'
         ? { ok: true }
@@ -3488,6 +3499,7 @@ async function runForeground(session: AuthSession): Promise<void> {
     buildArgv: (opts) => buildEngineLaunchArgv(session.engine, {
       ...opts,
       ...(session.cwd ? { cwd: session.cwd } : {}),
+      codexHome: session.codexHome,
       ...(launch.extraArgs?.length ? { extraArgs: launch.extraArgs } : {}),
       // A pane swap onto a grid has to clear the same vendor credentials a fresh create does, for the
       // same reason and against the same failure: an engine re-exec'd with the grid's variables still

--- a/cli/src/lib/agentFrame.spec.ts
+++ b/cli/src/lib/agentFrame.spec.ts
@@ -17,6 +17,14 @@ function session(grid: RegisteredSession['grid']): RegisteredSession {
 const assignment = { baseUrl: 'https://grid.autonomous.ai/grid-abc/relay', model: 'DeepSeek-V4-Flash-0731' }
 
 describe('agentFrame', () => {
+  it('keeps a Codex profile on both list and sync frames without adding it to legacy or other engines', async () => {
+    const selected = { ...session(null), engine: 'codex' as const, codexHome: '/accounts/two' }
+    const options = { selectedModel: null, terminalAvailable: true }
+    expect(await agentFrame(selected, options)).toHaveProperty('codexHome', '/accounts/two')
+    expect(await agentFrame(session(null), options)).not.toHaveProperty('codexHome')
+    expect(await agentFrame({ ...selected, engine: 'claude' }, options)).not.toHaveProperty('codexHome')
+  })
+
   // The regression this file exists for: `agent_synced` was built by a SECOND, hand-maintained copy
   // of this shape that never grew a `grid` field. The desktop rebuilds its Agent from every push, so
   // each sync reset an agent's grid to null and the "N agents are on an older target" banner came

--- a/cli/src/lib/agentFrame.ts
+++ b/cli/src/lib/agentFrame.ts
@@ -42,6 +42,7 @@ export type AgentFrame = {
   engine: RegisteredSession['engine']
   selectedModel: string | null
   grid: GridAssignment | null
+  codexHome?: string
 }
 
 /** What the caller knows and this module deliberately does not look up for itself. */
@@ -82,5 +83,6 @@ export async function agentFrame(
     // a real answer ("on no grid") and must be sent as one — omitting the key would make every push
     // indistinguishable from a daemon too old to know about grids.
     grid: s.grid ?? null,
+    ...(s.engine === 'codex' && s.codexHome !== undefined ? { codexHome: s.codexHome } : {}),
   }
 }

--- a/cli/src/lib/codexHome.spec.ts
+++ b/cli/src/lib/codexHome.spec.ts
@@ -1,0 +1,73 @@
+import { execFileSync } from 'node:child_process'
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { isCodexHome, resolveCodexHome } from './codexHome.js'
+import { buildEngineLaunchArgv } from './engineLaunch.js'
+
+let directory: string
+beforeEach(() => { directory = mkdtempSync(join(tmpdir(), 'harness-codex-profile-')) })
+afterEach(() => { rmSync(directory, { recursive: true, force: true }) })
+
+describe('local Codex account homes', () => {
+  it('accepts an existing home without reading or replacing credentials', () => {
+    const auth = join(directory, 'auth.json')
+    writeFileSync(auth, 'private fixture, deliberately not JSON')
+    expect(resolveCodexHome(directory)).toBe(realpathSync(directory))
+    expect(resolveCodexHome(auth)).toBeNull()
+    expect(resolveCodexHome(join(directory, 'missing'))).toBeNull()
+  })
+
+  it.each([null, '', 'codex2', '~/codex2', '/tmp/bad\npath', '/tmp/bad\0path', {}, []])(
+    'refuses a malformed home: %j', (value) => { expect(isCodexHome(value)).toBe(false) },
+  )
+
+  it('launches two accounts independently and treats shell syntax in a path as data', () => {
+    const executable = join(directory, 'fake-codex')
+    writeFileSync(executable, '#!/bin/sh\nprintf "%s" "$CODEX_HOME"\n')
+    chmodSync(executable, 0o700)
+    const homes = [join(directory, 'account one'), join(directory, "account'$(touch unwanted)")]
+    for (const codexHome of homes) {
+      mkdirSync(codexHome)
+      const argv = buildEngineLaunchArgv('codex', { codexHome }, '/bin/zsh')
+      // Run the exact launch body through a clean shell, with a harmless engine
+      // stand-in. This neither sources the developer's rc files nor starts Codex.
+      argv[4] = executable
+      const result = execFileSync('/bin/sh', ['-c', argv[2], ...argv.slice(3)], {
+        cwd: directory,
+        env: { ...process.env, CODEX_HOME: '/wrong/inherited/account' },
+        encoding: 'utf8',
+      })
+      expect(result).toBe(codexHome)
+    }
+    expect(existsSync(join(directory, 'unwanted'))).toBe(false)
+  })
+
+  it('preserves the selected home on resume and in the direct-launch fallback', () => {
+    const resumed = buildEngineLaunchArgv('codex', { codexHome: directory, resumeSessionId: 'session-two' }, '/bin/zsh')
+    expect(resumed[2]).toContain(`export CODEX_HOME='${directory}'`)
+    expect(resumed.slice(-2)).toEqual(['resume', 'session-two'])
+    const direct = buildEngineLaunchArgv('codex', { codexHome: directory }, '')
+    expect(direct.slice(0, 2)).toEqual(['env', `CODEX_HOME=${directory}`])
+    expect(() => buildEngineLaunchArgv('claude', { codexHome: directory })).toThrow('only be used with Codex')
+  })
+
+  it('enters the selected workspace after shell startup without losing the account', () => {
+    const cwd = join(directory, 'workspace with spaces')
+    const codexHome = join(directory, 'work-account')
+    mkdirSync(cwd)
+    mkdirSync(codexHome)
+    const executable = join(directory, 'fake-codex')
+    writeFileSync(executable, '#!/bin/sh\nprintf "%s\\n%s" "$CODEX_HOME" "$PWD"\n')
+    chmodSync(executable, 0o700)
+    const argv = buildEngineLaunchArgv('codex', { codexHome, cwd }, '/bin/zsh')
+    argv[argv.length - 1] = executable
+    const result = execFileSync('/bin/sh', ['-c', argv[2], ...argv.slice(3)], {
+      cwd: directory,
+      env: { ...process.env, CODEX_HOME: '/wrong/inherited/account' },
+      encoding: 'utf8',
+    })
+    expect(result).toBe(`${codexHome}\n${cwd}`)
+  })
+})

--- a/cli/src/lib/codexHome.ts
+++ b/cli/src/lib/codexHome.ts
@@ -1,0 +1,35 @@
+import { accessSync, constants, realpathSync, statSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { isAbsolute, join } from 'node:path'
+import { readProcessEnv } from './processEnv.js'
+import type { ProcessIdentity } from './terminalTypes.js'
+
+/** A state-directory path, never a shell command or a credential. */
+export function isCodexHome(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0 && value.length <= 4096
+    && !/[\x00-\x1f\x7f]/.test(value) && isAbsolute(value)
+}
+
+/** Resolve on the machine that will launch the agent, without reading auth.json. */
+export function resolveCodexHome(value: unknown): string | null {
+  if (!isCodexHome(value)) return null
+  try {
+    const directory = realpathSync(value)
+    if (!isCodexHome(directory)) return null
+    const info = statSync(directory)
+    if (!info.isDirectory()) return null
+    if (typeof process.getuid === 'function' && info.uid !== process.getuid()) return null
+    accessSync(directory, constants.R_OK | constants.W_OK | constants.X_OK)
+    return directory
+  } catch {
+    return null
+  }
+}
+
+/** Failed observation is unknown; it must not replace an already-selected home. */
+export async function probeCodexHome(identity: ProcessIdentity): Promise<string | undefined> {
+  const values = await readProcessEnv(identity)
+  if (!values) return undefined
+  const directory = values.CODEX_HOME || join(homedir(), '.codex')
+  return isCodexHome(directory) ? directory : undefined
+}

--- a/cli/src/lib/createAgentPane.spec.ts
+++ b/cli/src/lib/createAgentPane.spec.ts
@@ -98,6 +98,25 @@ describe('createAndRegisterPane', () => {
     expect(tmuxBackend.kill).toHaveBeenCalledTimes(3)
   })
 
+  it('retains the selected Codex home when registration retries a stale pane', async () => {
+    const { registry } = await loadRegistryModule()
+    registry.load()
+    registry.openPendingAgent({ engine: 'claude', runtimes: [{ backend: 'tmux', paneId: '%1' }], cwd: '/tmp/other' })
+    const tmuxBackend = fakeTmux([succeeded('%1'), succeeded('%2')])
+    const codexHome = join(dataDir, 'work-account')
+    const result = await createAndRegisterPane({
+      tmuxBackend, registry, engine: 'codex', cwd: '/tmp/demo', codexHome,
+      sessionLabel: 'harness-codex-1', argv: ['codex'],
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.spawned.runtime.paneId).toBe('%2')
+    expect(registry.byAgent(result.pending.agentId)?.codexHome).toBe(codexHome)
+    registry.load()
+    expect(registry.byAgent(result.pending.agentId)?.codexHome).toBe(codexHome)
+  })
+
   it('does not retry a tmux spawn failure', async () => {
     const { registry } = await loadRegistryModule()
     registry.load()

--- a/cli/src/lib/createAgentPane.ts
+++ b/cli/src/lib/createAgentPane.ts
@@ -27,10 +27,12 @@ export interface CreateAgentPaneDeps {
     runtimes: TmuxRuntimeRef[]
     primaryRuntimeKey?: string
     cwd?: string | null
+    codexHome?: string
     grid?: { baseUrl: string; model: string | null } | null
   }) => RegisteredSession | null }
   engine: AgentEngine
   cwd?: string | null
+  codexHome?: string
   /** Base tmux session name (`-s`). Retries append `-r<attempt>` — see module doc. */
   sessionLabel: string
   argv: string[]
@@ -66,6 +68,7 @@ export async function createAndRegisterPane(deps: CreateAgentPaneDeps): Promise<
       runtimes: [spawned.runtime],
       primaryRuntimeKey: terminalRouteKey(spawned.runtime),
       cwd: deps.cwd,
+      codexHome: deps.codexHome,
       grid: deps.grid,
     })
     if (pending) return { ok: true, spawned, pending }

--- a/cli/src/lib/engineLaunch.ts
+++ b/cli/src/lib/engineLaunch.ts
@@ -32,6 +32,8 @@ export const BYPASS_PERMISSION_FLAGS: Readonly<Record<AgentEngine, string[] | nu
 
 export interface LaunchCommandOptions {
   bypassPermission?: boolean
+  /** State and account for this Codex process only; never changes the daemon's environment. */
+  codexHome?: string
   /** Resume this engine session id on launch, when a launch-resume flag is known for the engine. */
   resumeSessionId?: string
   /**
@@ -182,13 +184,20 @@ export function buildEngineLaunchArgv(
   runtimeNode: string = managedNodePath(),
 ): string[] {
   const command = buildEngineCommandArgv(engine, opts)
+  if (opts.codexHome !== undefined && engine !== 'codex') {
+    throw new Error('A Codex profile can only be used with Codex')
+  }
   const interactive = interactiveEngineShell(shell)
-  if (!interactive) return command
+  if (!interactive) return opts.codexHome === undefined
+    ? command
+    : ['env', `CODEX_HOME=${opts.codexHome}`, ...command]
   // The clear comes FIRST, before the install as well as before the engine. An installer is a child
   // of this shell and inherits what it inherits: `npm` is not going to spend someone's Anthropic key,
   // but an install script that probes for credentials to configure itself would, and the whole point
   // of this launch is that the agent's environment is the one the user asked for.
+  // Apply AFTER shell startup, which may itself export a different CODEX_HOME.
   const prelude = clearEnvPrelude(opts.clearEnv)
+    + (opts.codexHome === undefined ? '' : `export CODEX_HOME=${shellSingleQuote(opts.codexHome)}\n`)
   // rc files (notably nvm) call getcwd() before running this command. Start the shell in a safe
   // directory and enter the selected workspace only after those files have loaded: an IDE can replace
   // a workspace inode between the desktop picker resolving it and tmux spawning the pane.

--- a/cli/src/lib/hooks.spec.ts
+++ b/cli/src/lib/hooks.spec.ts
@@ -71,6 +71,27 @@ describe('Codex hook installation', () => {
     expect(existsSync(`${file}.${process.pid}.tmp`)).toBe(false)
   })
 
+  it('links a second home without changing the first home or copying its credentials', async () => {
+    const selected = join(codexHome, 'account two')
+    mkdirSync(selected)
+    const original = join(codexHome, 'hooks.json')
+    writeFileSync(original, 'unchanged primary hooks')
+    const { installCodexHooks } = await loadHooks()
+    expect(installCodexHooks(19473, selected)).toBe(true)
+    const linked = JSON.parse(readFileSync(join(selected, 'hooks.json'), 'utf8'))
+    expect(linked.hooks.SessionStart[0].hooks[0].command).toContain(`--codex-home '${selected}'`)
+    expect(readFileSync(original, 'utf8')).toBe('unchanged primary hooks')
+    expect(existsSync(join(selected, 'auth.json'))).toBe(false)
+  })
+
+  it.each(['null', '[]', '42', '{"hooks": []}', '{"hooks": null}'])('refuses malformed profile hooks without rewriting %s', async (contents) => {
+    const file = join(codexHome, 'hooks.json')
+    writeFileSync(file, contents)
+    const { installCodexHooks } = await loadHooks()
+    expect(installCodexHooks(19473, codexHome)).toBe(false)
+    expect(readFileSync(file, 'utf8')).toBe(contents)
+  })
+
   it('merges Cursor lower-camel hooks and preserves foreign entries idempotently', async () => {
     const file = join(cursorHome, 'hooks.json')
     writeFileSync(file, JSON.stringify({
@@ -499,4 +520,3 @@ describe('Hermes hook allowlist', () => {
     expect(new Set(ours.map((a) => a.event)).size).toBe(ours.length)
   })
 })
-

--- a/cli/src/lib/hooks.ts
+++ b/cli/src/lib/hooks.ts
@@ -14,7 +14,6 @@ import { VERSION } from '../version.js'
 import { managedNodePath } from './nodeRuntime.js'
 
 const SETTINGS_PATH = join(homedir(), '.claude', 'settings.json')
-const CODEX_HOOKS_PATH = join(process.env.CODEX_HOME || join(homedir(), '.codex'), 'hooks.json')
 const GROK_HOOKS_PATH = join(env.GROK_HOME, 'hooks', 'harness.json')
 const CURSOR_HOOKS_PATH = join(process.env.CURSOR_HOME || join(homedir(), '.cursor'), 'hooks.json')
 // agy reads hooks from its SHARED customization root (~/.gemini/config), not from its own state dir —
@@ -57,7 +56,7 @@ function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`
 }
 
-function command(port: number, engine: 'claude' | 'codex' | 'cursor' | 'hermes' | 'commandcode' | 'devin' | 'grok' | 'agy' | 'copilot'): string {
+function command(port: number, engine: 'claude' | 'codex' | 'cursor' | 'hermes' | 'commandcode' | 'devin' | 'grok' | 'agy' | 'copilot', codexHome = env.CODEX_HOME): string {
   return [
     // Absolute, never the bare word `node`. This string is executed later by the ENGINE, in a shell
     // whose PATH is none of our business — and since the product ships its own Node, a computer with
@@ -68,7 +67,7 @@ function command(port: number, engine: 'claude' | 'codex' | 'cursor' | 'hermes' 
     '--port', String(port),
     '--data-dir', shellQuote(env.ADAPTER_DATA_DIR),
     '--claude-projects-dir', shellQuote(env.CLAUDE_PROJECTS_DIR),
-    '--codex-home', shellQuote(env.CODEX_HOME),
+    '--codex-home', shellQuote(codexHome),
     '--grok-home', shellQuote(env.GROK_HOME),
     '--cursor-home', shellQuote(env.CURSOR_HOME),
     '--hermes-home', shellQuote(env.HERMES_HOME),
@@ -144,20 +143,25 @@ function writeJsonAtomic(file: string, value: unknown): void {
 
 /** Merge Machine's user-level Codex hooks without replacing unrelated hooks. A malformed existing file
  * is left untouched: silently replacing it could disable user security/automation hooks. */
-export function installCodexHooks(port: number): void {
+export function installCodexHooks(port: number, codexHome = env.CODEX_HOME): boolean {
+  const hooksPath = join(codexHome, 'hooks.json')
   let settings: Settings = {}
-  if (existsSync(CODEX_HOOKS_PATH)) {
+  if (existsSync(hooksPath)) {
     try {
-      settings = JSON.parse(readFileSync(CODEX_HOOKS_PATH, 'utf-8')) as Settings
+      settings = JSON.parse(readFileSync(hooksPath, 'utf-8')) as Settings
+      if (!settings || typeof settings !== 'object' || Array.isArray(settings)
+        || (settings.hooks !== undefined && (!settings.hooks || typeof settings.hooks !== 'object' || Array.isArray(settings.hooks)))) {
+        throw new Error('Expected a hooks object')
+      }
     } catch (err) {
-      console.error(`[hooks] Codex hooks file is invalid JSON; leaving it unchanged: ${CODEX_HOOKS_PATH}`)
+      console.error(`[hooks] Codex hooks file is invalid JSON; leaving it unchanged: ${hooksPath}`)
       console.error('[hooks] fix the file, then restart harness login')
-      return
+      return false
     }
   }
   if (!settings.hooks || typeof settings.hooks !== 'object') settings.hooks = {}
 
-  const cmd = command(port, 'codex')
+  const cmd = command(port, 'codex', codexHome)
   const required: Array<{ event: 'SessionStart' | 'UserPromptSubmit'; matcher?: string }> = [
     { event: 'SessionStart', matcher: 'startup|resume|clear|compact' },
     { event: 'UserPromptSubmit' },
@@ -178,14 +182,16 @@ export function installCodexHooks(port: number): void {
 
   if (!changed) {
     console.log('[hooks] Codex SessionStart/UserPromptSubmit hooks already installed')
-    return
+    return true
   }
   try {
-    writeJsonAtomic(CODEX_HOOKS_PATH, settings)
-    console.log(`[hooks] installed Codex SessionStart/UserPromptSubmit hooks → ${CODEX_HOOKS_PATH}`)
+    writeJsonAtomic(hooksPath, settings)
+    console.log(`[hooks] installed Codex SessionStart/UserPromptSubmit hooks → ${hooksPath}`)
     console.log('[hooks] Codex requires reviewing these user hooks with /hooks before normal use')
+    return true
   } catch (err) {
     console.error('[hooks] failed to write Codex hooks.json:', err)
+    return false
   }
 }
 

--- a/cli/src/lib/registry.spec.ts
+++ b/cli/src/lib/registry.spec.ts
@@ -77,6 +77,31 @@ describe('registry remote display names', () => {
     delete process.env.CURSOR_HOME
   })
 
+  it('binds, persists and restores each Codex agent only within its own profile', async () => {
+    const { registry } = await loadRegistryModule()
+    registry.load()
+    const homes = [join(dataDir, 'account-one'), join(dataDir, 'account-two')]
+    const files = homes.map((home, index) => {
+      mkdirSync(join(home, 'sessions'), { recursive: true })
+      const file = join(home, 'sessions', `rollout-session-${index}.jsonl`)
+      writeFileSync(file, JSON.stringify({ type: 'session_meta', payload: { id: `session-${index}`, cwd: '/work' } }) + '\n')
+      return file
+    })
+    for (let index = 0; index < homes.length; index++) {
+      const opened = registry.openProcessAgent({
+        engine: 'codex', codexHome: homes[index], cwd: '/work', tmuxPane: `%${index + 1}`,
+        processIdentity: processIdentity(index + 201),
+      })
+      expect(opened?.entry.codexHome).toBe(homes[index])
+      expect(registry.register({ engine: 'codex', sessionId: `wrong-${index}`, transcriptPath: files[1 - index], tmuxPane: `%${index + 1}` })).toBeNull()
+      expect(registry.register({ engine: 'codex', sessionId: `session-${index}`, transcriptPath: files[index], tmuxPane: `%${index + 1}` })?.entry.codexHome).toBe(homes[index])
+    }
+    registry.load()
+    expect(registry.bySession('session-0')?.codexHome).toBe(homes[0])
+    expect(registry.bySession('session-1')?.codexHome).toBe(homes[1])
+    expect(registry.bySession('session-1')?.transcriptPath).toBe(files[1])
+  })
+
   it('persists renamed display names independently from session removal', async () => {
     const transcriptPath = join(dataDir, 'session-1.jsonl')
     writeFileSync(transcriptPath, '{}\n')

--- a/cli/src/lib/registry.ts
+++ b/cli/src/lib/registry.ts
@@ -35,6 +35,7 @@ import { join, basename, dirname, relative } from 'path'
 import { hostname, uptime } from 'os'
 import { env } from '../config/env.js'
 import { readCodexRolloutMeta, resolveCodexRollout } from '../engines/codex/rollout.js'
+import { isCodexHome } from './codexHome.js'
 import { ENGINES, type AgentEngine } from '../engines/types.js'
 import type { GridAssignment } from './gridAssignment.js'
 import { commandcodeTranscriptPath } from '../engines/commandcode/transcript.js'
@@ -99,6 +100,8 @@ export interface RegisteredSession {
    * exactly like `gateway`, never declared. See `gridAssignment.ts`. Carries no credential.
    */
   grid?: GridAssignment | null
+  /** Account and state directory observed on this process or selected for its pending launch. */
+  codexHome?: string
   /** Legacy launcher-owned snapshots may still contain this field. New records never write it. */
   launcherId?: string
   transcriptPath: string | null
@@ -478,7 +481,7 @@ function isWithin(root: string, file: string): boolean {
   return rel === '' || (!rel.startsWith('..') && !rel.startsWith(`/`) && !rel.startsWith(`\\`))
 }
 
-export function validTranscriptPath(engine: AgentEngine, filePath: string): boolean {
+export function validTranscriptPath(engine: AgentEngine, filePath: string, codexHome?: string): boolean {
   try {
     const actual = realpathSync(filePath)
     const root = realpathSync(
@@ -489,7 +492,7 @@ export function validTranscriptPath(engine: AgentEngine, filePath: string): bool
         : engine === 'muse'
         ? join(env.MUSE_HOME, 'sessions')
         : engine === 'codex'
-        ? join(env.CODEX_HOME, 'sessions')
+        ? join(codexHome ?? env.CODEX_HOME, 'sessions')
         : engine === 'grok'
         ? join(env.GROK_HOME, 'sessions')
         : engine === 'agy'
@@ -674,6 +677,11 @@ class Registry {
       let changed = false
       for (const raw of Array.isArray(arr) ? arr : []) {
         const engine = normalizedAgentEngine(raw?.engine)
+        if (engine === 'codex' && raw.codexHome !== undefined && !isCodexHome(raw.codexHome)) {
+          changed = true
+          continue
+        }
+        const codexHome = engine === 'codex' ? raw.codexHome as string | undefined : undefined
         const runtimes = normalizedRuntimes(raw?.runtimes, raw?.tmuxPane)
         const pane = tmuxProjection(runtimes)
         let transcriptPath =
@@ -687,9 +695,9 @@ class Registry {
           const meta = readCodexRolloutMeta(transcriptPath)
           if (meta?.isSubagent) {
             const repaired = meta.parentThreadId === rawSessionId
-              ? resolveCodexRollout(rawSessionId, join(env.CODEX_HOME, 'sessions'))
+              ? resolveCodexRollout(rawSessionId, join(codexHome ?? env.CODEX_HOME, 'sessions'))
               : null
-            if (!repaired || !validTranscriptPath('codex', repaired) || readCodexRolloutMeta(repaired)?.isSubagent) {
+            if (!repaired || !validTranscriptPath('codex', repaired, codexHome) || readCodexRolloutMeta(repaired)?.isSubagent) {
               changed = true
               bound = false
               transcriptPath = null
@@ -710,7 +718,7 @@ class Registry {
         }
         if (
           (bound && engine !== 'cursor' && engine !== 'opencode' && engine !== 'kilo' && engine !== 'pi' && engine !== 'hermes' && engine !== 'commandcode' && engine !== 'devin' && !transcriptPath)
-          || (bound && transcriptPath !== null && !validTranscriptPath(engine, transcriptPath))
+          || (bound && transcriptPath !== null && !validTranscriptPath(engine, transcriptPath, codexHome))
         ) {
           bound = false
           transcriptPath = null
@@ -733,6 +741,7 @@ class Registry {
           boundAt: bound ? (typeof raw.boundAt === 'number' ? raw.boundAt : (raw.registeredAt ?? now)) : null,
           engine,
           transcriptPath,
+          ...(codexHome !== undefined ? { codexHome } : {}),
           title: titleDisplayName(typeof raw.title === 'string' ? raw.title : null),
           sessionId: bound ? rawSessionId : '',
           projectDir: !repairedCodexTranscript && typeof raw.projectDir === 'string' && raw.projectDir
@@ -819,6 +828,7 @@ class Registry {
     processIdentity: ProcessIdentity
     gateway?: 'ori' | null
     grid?: GridAssignment | null
+    codexHome?: string
   }):
     {
       entry: RegisteredSession
@@ -869,6 +879,7 @@ class Registry {
       // the last good one said rather than silently downgrading a gateway agent to a vendor one.
       if (input.gateway !== undefined) existing.gateway = input.gateway
       if (input.grid !== undefined) existing.grid = input.grid
+      if (engine === 'codex' && isCodexHome(input.codexHome)) existing.codexHome = input.codexHome
       existing.updatedAt = Date.now()
       this.index(existing)
       this.terminalAvailableAgents.add(existing.agentId)
@@ -907,6 +918,7 @@ class Registry {
       engine,
       gateway: input.gateway ?? null,
       grid: input.grid ?? null,
+      ...(engine === 'codex' && isCodexHome(input.codexHome) ? { codexHome: input.codexHome } : {}),
       transcriptPath: null,
       projectDir: basename(input.cwd ?? '') || agentId,
       cwd: input.cwd ?? null,
@@ -936,6 +948,7 @@ class Registry {
     primaryRuntimeKey?: string
     cwd?: string | null
     grid?: GridAssignment | null
+    codexHome?: string
   }): RegisteredSession | null {
     if (this.writeBlocked) return null
     const runtimes = normalizedRuntimes(input.runtimes)
@@ -953,6 +966,7 @@ class Registry {
       engine: input.engine,
       gateway: null,
       grid: input.grid ?? null,
+      ...(input.engine === 'codex' && isCodexHome(input.codexHome) ? { codexHome: input.codexHome } : {}),
       transcriptPath: null,
       projectDir: basename(input.cwd ?? '') || agentId,
       cwd: input.cwd ?? null,
@@ -1030,7 +1044,7 @@ class Registry {
       // Copilot's session id is a uuid and names the directory its event stream lives in.
       || (engine === 'copilot' && !GROK_SESSION_RE.test(sessionId))
       || (engine !== 'cursor' && engine !== 'opencode' && engine !== 'kilo' && engine !== 'pi' && engine !== 'hermes' && engine !== 'commandcode' && engine !== 'devin' && engine !== 'grok' && engine !== 'agy' && engine !== 'copilot' && !transcriptPath)
-      || (transcriptPath && !validTranscriptPath(engine, transcriptPath))
+      || (transcriptPath && !validTranscriptPath(engine, transcriptPath, processAgent?.codexHome))
     ) return null
     if (engine === 'codex' && transcriptPath && readCodexRolloutMeta(transcriptPath)?.isSubagent) return null
 
@@ -1087,6 +1101,7 @@ class Registry {
       sessionId,
       boundAt: isNew ? now : existing?.boundAt ?? now,
       engine,
+      ...(existing?.codexHome !== undefined ? { codexHome: existing.codexHome } : {}),
       transcriptPath: effectiveTranscriptPath,
       projectDir: engine === 'grok' || engine === 'agy' || engine === 'copilot'
         ? basename(input.cwd ?? existing?.cwd ?? '') || sessionId
@@ -1234,6 +1249,7 @@ class Registry {
     processIdentity: ProcessIdentity,
     gateway?: 'ori' | null,
     grid?: GridAssignment | null,
+    codexHome?: string,
   ): boolean {
     const session = this.resolve(sessionId)
     if (!session || !validProcessIdentity(processIdentity)) return false
@@ -1245,6 +1261,7 @@ class Registry {
     // The grid is read from the same environment and follows the same rule. It matters most right
     // after a retarget: the respawned pane is a new pid, and this is where its new grid lands.
     if (grid !== undefined) session.grid = grid
+    if (session.engine === 'codex' && isCodexHome(codexHome)) session.codexHome = codexHome
     session.updatedAt = Date.now()
     this.index(session)
     this.save()

--- a/cli/src/lib/runtimeProfile.spec.ts
+++ b/cli/src/lib/runtimeProfile.spec.ts
@@ -31,6 +31,18 @@ function session(engine: RegisteredSession['engine']): RegisteredSession {
 }
 
 describe('RuntimeProfileManager', () => {
+  it('reads the model catalog from each Codex agent’s selected account home', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'codex-model-profiles-'))
+    cleanup.push(directory)
+    const manager = new RuntimeProfileManager()
+    for (const name of ['account-one', 'account-two']) {
+      const codexHome = join(directory, name)
+      await mkdir(codexHome)
+      await writeFile(join(codexHome, 'models_cache.json'), JSON.stringify({ models: [{ slug: name, display_name: name }] }))
+      const models = await manager.modelsForSession({ ...session('codex'), codexHome })
+      expect(models.map((model) => parseRuntimeProfile(model.id)?.model)).toEqual([name])
+    }
+  })
   it('limits Codex Max and Ultra to GPT-5.6 models', () => {
     expect(codexEffortAllowed('gpt-5.6-sol', 'max')).toBe(true)
     expect(codexEffortAllowed('gpt-5.6-terra', 'ultra')).toBe(true)

--- a/cli/src/lib/runtimeProfile.ts
+++ b/cli/src/lib/runtimeProfile.ts
@@ -1205,7 +1205,7 @@ export class RuntimeProfileManager {
     const output: RuntimeModelOption[] = []
     const seen = new Set<string>()
     let cache: CodexCache = {}
-    try { cache = JSON.parse(await readFile(join(env.CODEX_HOME, 'models_cache.json'), 'utf8')) as CodexCache } catch { /* current state fallback below */ }
+    try { cache = JSON.parse(await readFile(join(session.codexHome ?? env.CODEX_HOME, 'models_cache.json'), 'utf8')) as CodexCache } catch { /* current state fallback below */ }
     for (const item of Array.isArray(cache.models) ? cache.models : []) {
       const model = text(item.slug)
       if (!model || item.visibility === 'hide') continue

--- a/cli/src/lib/sessionRepair.spec.ts
+++ b/cli/src/lib/sessionRepair.spec.ts
@@ -41,6 +41,23 @@ const STARTED_AT = Date.parse('2026-08-03T09:00:00Z')
 const CWD = '/Users/demo/work/project'
 
 describe('session repair', () => {
+  it('repairs two Codex sessions in the same working folder only from their selected homes', async () => {
+    const homes = [tempRoot(), tempRoot()]
+    for (let index = 0; index < homes.length; index++) {
+      const sessions = join(homes[index], 'sessions')
+      mkdirSync(sessions)
+      const file = join(sessions, `rollout-${index}.jsonl`)
+      writeFileSync(file, JSON.stringify({ type: 'session_meta', payload: { id: `account-${index}`, cwd: CWD } }) + '\n')
+      utimesSync(file, new Date(STARTED_AT + 5_000), new Date(STARTED_AT + 5_000))
+    }
+    const { findLiveSession } = await load(tempRoot())
+    for (let index = 0; index < homes.length; index++) {
+      await expect(findLiveSession('codex', CWD, STARTED_AT, { codexHome: homes[index], bornOnly: true }))
+        .resolves.toMatchObject({ sessionId: `account-${index}` })
+    }
+    await expect(findLiveSession('codex', CWD, STARTED_AT, { codexHome: tempRoot() })).resolves.toBeNull()
+  })
+
   it('finds the session the running engine started in this directory', async () => {
     const root = tempRoot()
     writeTranscript(root, 'proj', 'sess-live', CWD, STARTED_AT + 5_000)

--- a/cli/src/lib/sessionRepair.ts
+++ b/cli/src/lib/sessionRepair.ts
@@ -242,7 +242,7 @@ export async function findLiveSession(
   engine: AgentEngine,
   cwd: string,
   startedAtMs: number,
-  opts?: { bornOnly?: boolean; pid?: number },
+  opts?: { bornOnly?: boolean; pid?: number; codexHome?: string },
 ): Promise<RepairedSession | null> {
   const sinceMs = startedAtMs - START_SLACK_MS
   // The DB engines match on a directory STRING, so ask for both spellings of it (see sameDir).
@@ -257,7 +257,7 @@ export async function findLiveSession(
       // belongs to a subagent, which must never become an agent of its own.
       // Its session id lives INSIDE the file: the name is `rollout-<timestamp>-<id>.jsonl`, so deriving
       // the id from the filename produced the literal string "rollout-…" (seen on a live pane).
-      return fileEngineSession(join(env.CODEX_HOME, 'sessions'), cwd, startedAtMs, async (path) => {
+      return fileEngineSession(join(opts?.codexHome ?? env.CODEX_HOME, 'sessions'), cwd, startedAtMs, async (path) => {
         const meta = readCodexRolloutMeta(path)
         return meta && !meta.isSubagent ? { cwd: meta.cwd, sessionId: meta.id || undefined } : null
       }, opts)

--- a/cli/src/lib/terminalAgentDiscovery.ts
+++ b/cli/src/lib/terminalAgentDiscovery.ts
@@ -6,6 +6,7 @@ import {
   type AgentCommandOwnershipSnapshot,
 } from './engineBin.js'
 import { probeGatewayRuntime } from './gatewayRuntime.js'
+import { probeCodexHome } from './codexHome.js'
 import { probeGridAssignment, type GridAssignment } from './gridAssignment.js'
 import type { TerminalBackend } from './terminalBackend.js'
 import {
@@ -29,6 +30,7 @@ export { processRows } from './tmux.js'
 
 export interface DiscoveredTerminalAgent {
   engine: AgentEngine
+  codexHome?: string
   cwd: string
   processIdentity: ProcessIdentity
   args: string
@@ -245,6 +247,7 @@ export async function probeTerminalAgents(
     agent.gateway = runtime.kind
     // Same process, same cached read — the grid costs no extra `ps`.
     agent.grid = await probeGridAssignment(agent.processIdentity, agent.engine, agent.args)
+    if (agent.engine === 'codex') agent.codexHome = await probeCodexHome(agent.processIdentity)
   }))
   return { processTableAvailable: true, targets, ...discovered }
 }


### PR DESCRIPTION
Users with separate Codex logins behind shortcuts such as `codex1` and `codex2` need each agent to use the corresponding `CODEX_HOME`. The daemon currently uses one global home for launch, transcript binding and model lookup.

This adds optional `agent_create.codexHome` and an explicit `engines_probe` capability. The selected directory is validated on the target machine and applied after shell startup. Discovery, hooks, registry persistence, transcript repair, model catalogs and restart/resume retain that agent's home. The selected home is also retained through pane-registration retries and entering the working folder after shell startup. Agent frames expose the directory for Desktop to identify the selected profile. Invalid choices and malformed hook files fail before launch; credential files are neither read for linking nor copied.

Companion implementation for autonomous-ai/autonomous-harness-desktop#15 and https://github.com/autonomous-ai/autonomous-harness-desktop/pull/17. The Desktop picker requires this CLI support to be released. Profile selection applies to Codex launches using their own account; a simultaneous Grid override is rejected.

Merge and release this CLI change before releasing the companion Desktop change.

Validation after rebasing onto `345e00f`, on macOS, Node 26.0.0, tmux 3.7c:

- `npm run typecheck` passed.
- `npm test -- --maxWorkers=2`: 2,010 passed, 51 gated tests skipped.
- `npm run test:tmux-real`: 8 passed, 9 unavailable engine rows skipped. Exercised Codex, Cursor, Pi, Command Code, Grok, the Grok `agent` alias, lifecycle and literal input.
- Tests cover separate account folders and transcripts, persistent bindings, profile-specific model caches, shell quoting, resume, RPC validation and preserving existing credentials/hooks. Added regression coverage for a profile surviving registration retries and selecting both the working folder and account in the same launch.

The first unrestricted concurrent suite hit unrelated timing failures in terminal framing and OpenCode incremental reads; the bounded-worker run passed. Herdr is not installed. Linux and real model calls across two accounts have not been exercised.

Native integration was verified on feature commit `99e9db8` using the managed Node 22.23.2 runtime; the rebased head was checked with the suites above. A new agent was launched from Desktop with the existing `.codex-account-2` profile; its live process environment and registry both report that selected home. The original default-profile Codex process retained its PID and pane. The installed CLI bundle is unchanged. The development daemon remains on `99e9db8` with startup-wide hook installation and self-update disabled to preserve the two active agents; rebasing and verification used a separate worktree.
